### PR TITLE
Add support for data:text/tml urls

### DIFF
--- a/app/models/iframe.rb
+++ b/app/models/iframe.rb
@@ -46,7 +46,7 @@ class Iframe < Content
   end
 
   def url_must_exist
-    if config['url'].empty? || (config['url'] =~ /[a-z]+\:\/\/.+/).nil?
+    if config['url'].empty? || (config['url'] =~ /[a-z]+\:\/\/.+/).nil? &&  !config['url'].starts_with?("data:text/html")
       errors.add(:url, 'an absolute Url must be specified')
     end
   end


### PR DESCRIPTION
Added Support for inline iframe content. This allows urls of type "data:text/html" to be specified in the URL field. The HTML of the iframe then follows in either URL-encoded format or base64 econded format.

For example, the url specified as 
```
   data:text/html;charset=utf-8;base64, PGh0bWw+PGJvZHk+SGVsbG8gV29ybGQ8L2JvZHk+PC9odG1sPg==
```
Will add an iframe with the "hello world" text in it.